### PR TITLE
Implement Read-Only mode for mtnd

### DIFF
--- a/libmtn.h
+++ b/libmtn.h
@@ -41,6 +41,7 @@
 #define MTNCMD_STDIN    30
 #define MTNCMD_STDOUT   31
 #define MTNCMD_STDERR   32
+#define MTNCMD_RDONLY   33
 #define MTNCMD_ERROR    97
 #define MTNCMD_SUCCESS  98
 #define MTNCMD_MAX      99

--- a/libmtn.h
+++ b/libmtn.h
@@ -58,6 +58,7 @@
 
 #define MTNMODE_EXPORT  1
 #define MTNMODE_EXECUTE 2
+#define MTNMODE_RDONLY  4
 
 typedef struct statm
 {

--- a/mtn.h
+++ b/mtn.h
@@ -253,6 +253,7 @@ int mtn_read(MTN *mtn, int s, char *buf, size_t size, off_t offset);
 int mtn_write(MTN *mtn, int s, const char *buf, size_t size, off_t offset);
 int mtn_flush(MTN *mtn, int s);
 int mtn_exec(MTN *mtn, MTNJOB *job);
+int mtn_rdonly(MTN *mtn, const char *host, int flag);
 
 MTNDIR  *newdir(const char *path);
 MTNDIR  *deldir(MTNDIR *md);

--- a/mtnd.c
+++ b/mtnd.c
@@ -54,6 +54,7 @@ void usage()
   printf("   -D num           # debug level\n");
   printf("   -l size          # limit size (MB)\n");
   printf("   --pid=path       # pid file(ex: /var/run/mtnfs.pid)\n");
+  printf("   --rdonly         # read only\n");
   printf("\n");
 }
 
@@ -306,6 +307,9 @@ static void mtnd_info_process(MTNTASK *kt)
       }
     }
   }
+  if(ctx->rdonly){
+    mb.dfree = 0;
+  }
   mb.cnt.prc = getpscount();
   mb.cnt.cld = get_task_count(ctx->cldtask);
   mb.cnt.mbr = get_members_count(ctx->members);
@@ -322,6 +326,7 @@ static void mtnd_info_process(MTNTASK *kt)
   mb.loadavg = (uint32_t)(loadavg * 100);
   mb.flags  |= ctx->export  ? MTNMODE_EXPORT  : 0;
   mb.flags  |= ctx->execute ? MTNMODE_EXECUTE : 0;
+  mb.flags  |= ctx->rdonly  ? MTNMODE_RDONLY  : 0;
   mtndata_set_int(&(mb.dsize),      &(kt->send), sizeof(mb.dsize));
   mtndata_set_int(&(mb.dfree),      &(kt->send), sizeof(mb.dfree));
   mtndata_set_int(&(sm.vsz),        &(kt->send), sizeof(sm.vsz));
@@ -1020,6 +1025,7 @@ struct option *get_optlist()
       {"export",  1, NULL, 'e'},
       {"execute", 1, NULL, 'E'},
       {"group",   1, NULL, 'g'},
+      {"rdonly",  0, NULL, 'r'},
       {0, 0, 0, 0}
     };
   return(opt);
@@ -1070,6 +1076,7 @@ void mtnd_startmsg()
   mtnlogger(mtn, 0, "size : %6llu [MB]\n", (dsize + ctx->free_limit) / 1024 / 1024);
   mtnlogger(mtn, 0, "free : %6llu [MB]\n", (dfree + ctx->free_limit) / 1024 / 1024);
   mtnlogger(mtn, 0, "limit: %6llu [MB]\n", ctx->free_limit / 1024 / 1024);
+  mtnlogger(mtn, 0, "mode : %s\n", ctx->rdonly ? "RDONLY" : "RDWR");
   }
 }
 
@@ -1159,7 +1166,7 @@ void parse(int argc, char *argv[])
     usage();
     exit(0);
   }
-  while((r = getopt_long(argc, argv, "hvng:E:e:l:m:p:P:D:", get_optlist(), NULL)) != -1){
+  while((r = getopt_long(argc, argv, "hvng:E:e:l:m:p:P:D:r", get_optlist(), NULL)) != -1){
     switch(r){
       case 'h':
         usage();
@@ -1217,6 +1224,10 @@ void parse(int argc, char *argv[])
         }else{
           sprintf(ctx->pid, "%s/%s", ctx->cwd, optarg);
         }
+        break;
+
+      case 'r':
+        ctx->rdonly = 1;
         break;
 
       case '?':

--- a/mtnd.c
+++ b/mtnd.c
@@ -670,9 +670,14 @@ int mtnd_cld_process(int s)
         mtnlogger(mtn, 0, "[error] %s: %s\n", __func__, strerror(errno));
       }
       if(r == 0){
-        if(data.head.type == MTNCMD_OPEN){
-          mtndata_get_int(&(n->init.use), &data, sizeof(n->init.use));
-          mtndata_get_string(n->path, &data);
+        switch(data.head.type){
+          case MTNCMD_OPEN:
+            mtndata_get_int(&(n->init.use), &data, sizeof(n->init.use));
+            mtndata_get_string(n->path, &data);
+            break;
+          case MTNCMD_RDONLY:
+            mtndata_get_int(&(ctx->rdonly), &data, sizeof(ctx->rdonly));
+            break;
         }
       }
       return(1);

--- a/mtnd.h
+++ b/mtnd.h
@@ -28,6 +28,7 @@ typedef struct mtnd_context{
   int  signal;
   int  export;
   int  execute;
+  int  rdonly;
   int  fsig[2];
 } MTND;
 

--- a/mtnd_child.c
+++ b/mtnd_child.c
@@ -694,6 +694,23 @@ static void mtnd_child_exec(MTNTASK *kt)
   mtnlogger(mtn, 8, "[debug] %s: return\n", __func__);
 }
 
+static void mtnd_child_rdonly(MTNTASK *kt)
+{
+  int flag;
+  MTNDATA data;
+  mtnlogger(mtn, 9, "[debug] %s: IN\n", __func__);
+  mtndata_get_int(&flag, &(kt->recv), sizeof(flag));
+  memset(&data, 0, sizeof(data));
+  data.head.ver  = PROTOCOL_VERSION;
+  data.head.type = MTNCMD_RDONLY;
+  data.head.size = 0;
+  mtndata_set_int(&(flag), &data, sizeof(flag));
+  if(send_data_stream(mtn, kt->wpp, &data) == -1){
+    mtnlogger(mtn, 0, "[error]  %s: %s\n", __func__, strerror(errno));
+  }
+  mtnlogger(mtn, 9, "[debug] %s: OUT\n", __func__);
+}
+
 static void mtnd_child_error(MTNTASK *kt)
 {
   errno = EACCES;
@@ -723,6 +740,7 @@ void init_task_child()
   taskfunc[MTNCMD_INIT]     = mtnd_child_init;
   taskfunc[MTNCMD_EXIT]     = mtnd_child_exit;
   taskfunc[MTNCMD_EXEC]     = mtnd_child_exec;
+  taskfunc[MTNCMD_RDONLY]   = mtnd_child_rdonly;
 }
 
 void mtnd_child(MTNTASK *kt)

--- a/mtnfile.c
+++ b/mtnfile.c
@@ -44,16 +44,18 @@ void usage()
   printf("usage: %s [OPTION] [HOST]:REMOTE_PATH\n", MODULE_NAME);
   printf("\n");
   printf("  OPTION\n");
-  printf("   -h            (--help)    # help\n");
-  printf("   -v            (--version) # show version\n");
-  printf("   -i            (--info)    # show infomation\n");
-  printf("   -c            (--choose)  # choose host\n");
-  printf("   -u nnnn[KMG]  (--use)     # use space\n");
-  printf("   -P LOCAL_PATH (--put)     # file upload\n");
-  printf("   -G LOCAL_PATH (--get)     # file download\n");
-  printf("   -D            (--delete)  # file delete\n");
-  printf("   -m addr                   # multicast addr\n");
-  printf("   -p port                   # multicast port\n");
+  printf("   -h            (--help)      # help\n");
+  printf("   -v            (--version)   # show version\n");
+  printf("   -i            (--info)      # show infomation\n");
+  printf("   -c            (--choose)    # choose host\n");
+  printf("   -u nnnn[KMG]  (--use)       # use space\n");
+  printf("   -P LOCAL_PATH (--put)       # file upload\n");
+  printf("   -G LOCAL_PATH (--get)       # file download\n");
+  printf("   -D            (--delete)    # file delete\n");
+  printf("   -m addr                     # multicast addr\n");
+  printf("   -p port                     # multicast port\n");
+  printf("   -R host       (--rdonly)    # set read-only mode\n");
+  printf("   -W host       (--no-rdonly) # set read-write mode\n");
 
   printf("\n");
 }
@@ -270,6 +272,11 @@ int mtnfile_del(STR remote)
   return(0);
 }
 
+int mtnfile_rdonly(STR host, int flag)
+{
+  return(mtn_rdonly(mtn, host, flag));
+}
+
 int mtnfile_console_help(STR cmd)
 {
   if(!cmd){
@@ -442,14 +449,16 @@ int mtnfile_console()
 }
 
 static struct option opts[]={
-  {"help",    0, NULL, 'h'},
-  {"version", 0, NULL, 'v'},
-  {"info",    0, NULL, 'i'},
-  {"choose",  0, NULL, 'c'},
-  {"put",     1, NULL, 'P'},
-  {"get",     1, NULL, 'G'},
-  {"delete",  0, NULL, 'D'},
-  {NULL,      0, NULL, 0}
+  {"help",      0, NULL, 'h'},
+  {"version",   0, NULL, 'v'},
+  {"info",      0, NULL, 'i'},
+  {"choose",    0, NULL, 'c'},
+  {"put",       1, NULL, 'P'},
+  {"get",       1, NULL, 'G'},
+  {"delete",    0, NULL, 'D'},
+  {"rdonly",    1, NULL, 'R'},
+  {"no-rdonly", 1, NULL, 'W'},
+  {NULL,        0, NULL, 0}
 };
 
 int init(int argc, char *argv[])
@@ -468,7 +477,7 @@ int init(int argc, char *argv[])
   mtn->logtype = 0;
   mtn->logmode = MTNLOG_STDERR;
   ctx->mode    = (argc == 1) ? MTNTOOL_CONSOLE : MTNTOOL_LIST;
-  while((r = getopt_long(argc, argv, "P:G:Du:m:p:hvicd", opts, NULL)) != -1){
+  while((r = getopt_long(argc, argv, "R:W:P:G:Du:m:p:hvicd", opts, NULL)) != -1){
     switch(r){
       case 'h':
         usage();
@@ -540,6 +549,16 @@ int init(int argc, char *argv[])
         mtn->mcast_port = atoi(optarg);
         break;
 
+      case 'R':
+        ctx->remote_host = newstr(optarg);
+        ctx->mode = MTNTOOL_RDONLY;
+        break;
+
+      case 'W':
+        ctx->remote_host = newstr(optarg);
+        ctx->mode = MTNTOOL_NORDONLY;
+        break;
+
       case '?':
         usage();
         exit(1);
@@ -592,6 +611,14 @@ int main(int argc, char *argv[])
 
     case MTNTOOL_DEL:
       r = mtnfile_del(ctx->remote_path);
+      break;
+
+    case MTNTOOL_RDONLY:
+      r = mtnfile_rdonly(ctx->remote_host, 1);
+      break;
+
+    case MTNTOOL_NORDONLY:
+      r = mtnfile_rdonly(ctx->remote_host, 0);
       break;
   }
   exit(r);

--- a/mtnfile.c
+++ b/mtnfile.c
@@ -109,6 +109,9 @@ int mtnfile_info()
     printf("STR=%d ",     s->cnt.str);
     printf("ARG=%d ",     s->cnt.arg);
     printf("CLD=%d ",     s->cnt.cld);
+    if(s->flags & MTNMODE_RDONLY){
+      printf("RDONLY ");
+    }
     printf("\n");
   }
   if(!node){

--- a/mtnfile.h
+++ b/mtnfile.h
@@ -2,14 +2,16 @@
  * mtnfile.h
  * Copyright (C) 2011 KLab Inc.
  */
-#define MTNTOOL_ERROR   0
-#define MTNTOOL_CONSOLE 1
-#define MTNTOOL_INFO    2
-#define MTNTOOL_LIST    3
-#define MTNTOOL_CHOOSE  4
-#define MTNTOOL_PUT     5
-#define MTNTOOL_GET     6
-#define MTNTOOL_DEL     7
+#define MTNTOOL_ERROR    0
+#define MTNTOOL_CONSOLE  1
+#define MTNTOOL_INFO     2
+#define MTNTOOL_LIST     3
+#define MTNTOOL_CHOOSE   4
+#define MTNTOOL_PUT      5
+#define MTNTOOL_GET      6
+#define MTNTOOL_DEL      7
+#define MTNTOOL_RDONLY   8
+#define MTNTOOL_NORDONLY 9
 #define MAX(a, b) ((a < b) ? b : a)
 
 typedef struct mtnfile_context


### PR DESCRIPTION
mtnd に読み込み専用モードを実装しました。
読み込み専用モードに設定された mtnd は MTNCMD_INFO の要求に対して、空きディスク容量を 0 で応答し、ファイル書き込みの対象から外れるようになります。
