### PR TITLE
メモリリークを修正

### DIFF
--- a/libmtn.c
+++ b/libmtn.c
@@ -3607,8 +3607,9 @@ ARG splitstr(STR str, STR delim)
   char *save = NULL;
   STR ptr = NULL;
   STR buf = newstr(str);
-  ARG arg = newarg(0);
+  ARG arg = NULL;
   if(buf){
+    arg = newarg(0);
     ptr = strtok_r(buf, delim, &save);
     while(ptr){
       arg = addarg(arg, ptr);


### PR DESCRIPTION
メモリリークを発見したので修正しました。

メモリリークの原因は、cpsvr() 経由で呼ばれた splitstr() が確保したメモリを示すポインタ（MTNSVR->grouparg）を、mtn_info_process() 内で上書きしてしまっていることです。mtn_info_process() は MTNSVR->grouparg が NULL であることを想定していますが、splitstr() が空文字を渡されても必ずnewarg() でメモリを確保してしまうため、MTNSVR->grouparg が newarg() で確保したメモリを参照した状態になっていて、これを上書きしてまいます。そもそも splitstr() が不要なメモリを確保していることが原因なので、空文字を渡された場合には不要なメモリを確保しないように修正しました。

なお、mtn_info_process() は mtn_info() から呼ばれており、mtn_info() は FUSE から statfs のコールバック関数として呼び出されるため、df のようにファイルシステムの統計情報を取得する操作を行なった場合にメモリリークが発生してしまいます。

**修正前**

```
# for i in $(seq 1 1000); do df > /dev/null; done; sleep 1; cat /root/LOCAL/mnt/.mtnstatus/debuginfo
[DEBUG INFO]
VSZ   : 29564 KB
RSS   : 808 KB
SVR   : 1
DIR   : 0
STAT  : 0
STR   : 1
ARG   : 1000
MALLOC: 5
RCVBUF: 131071
```

**修正後**

```
# for i in $(seq 1 1000); do df > /dev/null; done; sleep 1; cat /root/LOCAL/mnt/.mtnstatus/debuginfo
[DEBUG INFO]
VSZ   : 29564 KB
RSS   : 804 KB
SVR   : 1
DIR   : 0
STAT  : 0
STR   : 1
ARG   : 0
MALLOC: 5
RCVBUF: 131071
```

＊ 試験は mtnd 1台で行っていますが、mtnd の数が増えるとリーク件数も比例して増加すると思われます。
