### PR TITLE
子プロセスとのパイプ通信でブロックしてしまう問題を修正

### DIFF
--- a/libmtn.h
+++ b/libmtn.h
@@ -126,6 +126,7 @@ typedef struct mtntask
   MTNDATA recv;
   MTNDATA keep;
   MTNSTAT *kst;
+  size_t nrecv;
   struct mtntask *prev;
   struct mtntask *next;
   char  path[PATH_MAX];


### PR DESCRIPTION
子プロセスとの通信で使用しているパイプの読み出し処理でブロックしていまい、その他のディスクリプタの読み出しがストップしてしまう問題を修正しました。
