### PR TITLE
mtnd が応答するディレクトリエントリにドットファイルが含まれない問題を修正

### DIFF
--- a/mtnd.c
+++ b/mtnd.c
@@ -142,7 +142,7 @@ uint64_t get_datasize(char *path)
   struct stat st;
 
   while((ent = readdir(d))){
-    if(ent->d_name[0] == '.'){
+    if(strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0){
       continue;
     }
     sprintf(full, "%s/%s", path, ent->d_name);
@@ -351,7 +351,7 @@ int mtnd_list_dir(MTNTASK *kt)
   struct  dirent *ent;
   char full[PATH_MAX];
   while((ent = readdir(kt->dir))){
-    if(ent->d_name[0] == '.'){
+    if(strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0){
       continue;
     }
     sprintf(full, "%s/%s", kt->path, ent->d_name);


### PR DESCRIPTION
mtnd が応答するディレクトリエントリにドットファイルが含まれない問題を修正しました。

mtnd 側のディレクトリエントリを返す処理で、`.` ではじまるエントリを全てスキップしていたため、`.` および `..` のみをスキップするように変更しました。

**修正前**
ドットファイルの作成はできるが、ディレクトリエントリに含まれていないので、`ls` で表示できない。また、ドットファイルが含まれるディレクトリを削除しようとしても削除できない。

```
mtnfs:~/LOCAL/mnt# mkdir dir
mtnfs:~/LOCAL/mnt# touch dir/{.dotfile,regfile}
mtnfs:~/LOCAL/mnt# ls -a dir
.  ..  regfile
mtnfs:~/LOCAL/mnt# rm -rf dir
mtnfs:~/LOCAL/mnt# ls -a 
.  ..  .mtnstatus  dir
mtnfs:~/LOCAL/mnt# ls -a dir
.  ..
```

`rm -rf` でディレクトリを削除しようとしたタイミングで、mtnd 側でもエラーを吐いている。

```
15.978300 [07140] [error] mtnd_rm_process: Directory not empty ./dir
```

直接ファイル名を指定すればアクセス可能なので、ドットファイルを消せばディレクトリも消せる。

```
mtnfs:~/LOCAL/mnt# rm dir/.dotfile
rm: remove regular empty file `dir/.dotfile'? y
mtnfs:~/LOCAL/mnt# rm -rf dir
mtnfs:~/LOCAL/mnt# ls -a
.  ..  .mtnstatus
```

**修正後**
`ls` での表示もドットファイルが含まれるディレクトリの削除も問題なく行える。

```
mtnfs:~/LOCAL/mnt# mkdir dir
mtnfs:~/LOCAL/mnt# touch dir/{.dotfile,regfile}
mtnfs:~/LOCAL/mnt# ls -a dir
.  ..  .dotfile  regfile
mtnfs:~/LOCAL/mnt# rm -rf dir
mtnfs:~/LOCAL/mnt# ls -a 
.  ..  .mtnstatus
```
