### PR TITLE
UDPの応答メッセージのシーケンス番号をチェックするよう修正

### DIFF
--- a/libmtn.c
+++ b/libmtn.c
@@ -1854,6 +1854,9 @@ static int mtn_process_recv(MTN *mtn, int s, MTNSVR *members, MTNDATA *sdata, MT
   memset(&raddr, 0, sizeof(raddr));
   raddr.len = sizeof(raddr.addr);
   while(recv_dgram(mtn, s, &rdata, &(raddr.addr.addr), &(raddr.len)) == 0){
+    if(rdata.head.sqno != sdata->head.sqno) {
+      continue;
+    }
     if(members == NULL){
       r = mtn_process_hello(mtn, s, sdata, &rdata, saddr, &raddr, mtnproc);
     }else{

--- a/mtnd.c
+++ b/mtnd.c
@@ -180,6 +180,7 @@ MTNTASK *mtnd_task_create(MTNDATA *data, MTNADDR *addr)
   memcpy(&(kt->addr), addr, sizeof(MTNADDR));
   memcpy(&(kt->recv), data, sizeof(MTNDATA));
   kt->type = data->head.type;
+  kt->send.head.sqno = data->head.sqno;
   mtnlogger(mtn,8, "[debug] %s: CMD=%s SEQ=%d\n", __func__, mtncmdstr[kt->type], data->head.sqno);
   if(tasklist){
     tasklist->prev = kt;


### PR DESCRIPTION
UDPの応答メッセージにシーケンス番号がセットされていないため、UDPのローカルポートが使いまわされた場合に、（既に使い終わったソケットで送信した）以前のリクエストに対する応答メッセージを遅れて受信し、それを誤って処理してしまう不具合がありました。

これは、頻繁に投げられる stat 情報取得のメッセージに対する古い応答が、新しい UDP ソケットに対して流れ込んで来てしまい、存在しないはずのファイルが「存在する」と扱われてしまう問題として顕著に発生していました。

```
cp: 通常ファイル `./linux-4.6/sound/firewire/lib.c' を作成できません: ファイルが存在します
```

そこで、この問題を解決するために、UDPの応答メッセージにシーケンス番号を正しくセットし、リクエストを投げた側で、応答メッセージの整合性をチェックするよう修正しました。リクエストと応答メッセージのシーケンス番号が一致しなかった場合、その応答メッセージを無視するようにしました。

手元の試験環境でテストを行い、修正適用後は上記のエラーは発生しなくなりました。
